### PR TITLE
sqlite-to-fdb: remove template fdb requirement

### DIFF
--- a/modules/fdb/README.md
+++ b/modules/fdb/README.md
@@ -71,9 +71,14 @@ $ cargo run --example fdb-to-sqlite <input fdb> <output sqlite>
 ### sqlite-to-fdb
 
 Convert an SQLite database to FDB
-Because there is no 1:1 mapping of FDB and SQLite value types, you first need to create a 'template' FDB file containing the column names and types.
+
+```shell
+$ cargo run --example sqlite-to-fdb <input sqlite> <output fdb>
+```
+
+If your SQLite database was generated with an old version of `fdb-to-sqlite`, it will be missing column type information. In this case, you can can first turn an existing FDB file into a template containing only the column names and types, and then supply this file to `sqlite-to-fdb`:
 
 ```shell
 $ cargo run --example template-fdb <input fdb> <output template fdb>
-$ cargo run --example sqlite-to-fdb <input template fdb> <input sqlite> <output fdb>
+$ cargo run --example sqlite-to-fdb <input sqlite> <output fdb> --template <input template fdb> 
 ```

--- a/modules/fdb/examples/sqlite-to-fdb.rs
+++ b/modules/fdb/examples/sqlite-to-fdb.rs
@@ -51,10 +51,12 @@ fn main() -> eyre::Result<()> {
 
         // Get column types
         for column in &statement.columns() {
-            let decl_type = column.decl_type().expect("Failed to get column type");
+            let decl_type = column
+                .decl_type()
+                .expect("The SQLite database is missing column type information.");
 
-            let target_type =
-                ValueType::from_sqlite_type(decl_type).expect("Failed to convert column type");
+            let target_type = ValueType::from_sqlite_type(decl_type)
+                .expect("The SQLite database contains an unknown column type.");
 
             target_types.push(target_type);
         }

--- a/modules/fdb/examples/sqlite-to-fdb.rs
+++ b/modules/fdb/examples/sqlite-to-fdb.rs
@@ -1,24 +1,30 @@
-use assembly_fdb::{common::Latin1String, common::ValueType, core::Field, store};
+use assembly_fdb::{common::Latin1String, common::ValueType, core::Field, mem::Database, store};
 use color_eyre::eyre::{self, eyre, WrapErr};
+use mapr::Mmap;
 use rusqlite::{types::ValueRef, Connection};
-use std::{fs::File, io::BufWriter, path::PathBuf, time::Instant};
+use std::{fmt::Write, fs::File, io::BufWriter, path::PathBuf, time::Instant};
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
-/// Fills a template FDB file (see template-fdb.rs) with rows from a sqlite database
+#[structopt(name = "sqlite-to-fdb")]
+#[structopt(author = "zaop")]
+/// Convert an SQLite database to FDB. By default, type information from the SQLite DB is used; if unavailable, you can specify the target
+/// datatypes through a 'template' FDB file with `--template` (see template-fdb.rs).
 struct Options {
-    /// Input sqlite database
+    /// Input SQLite file
     src: PathBuf,
     /// Output FDB file
     dest: PathBuf,
+    /// Optional: an FDB file containing tables with correct columns but no rows used to determine type information
+    #[structopt(long, default_value = "")]
+    template: PathBuf,
 }
 
 fn main() -> eyre::Result<()> {
     color_eyre::install()?;
     let opts = Options::from_args();
-    let start = Instant::now();
 
-    println!("Converting database, this may take a few seconds...");
+    let start = Instant::now();
 
     // sqlite input
     let conn = Connection::open_with_flags(&opts.src, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
@@ -26,9 +32,50 @@ fn main() -> eyre::Result<()> {
 
     // fdb output
     let dest_file = File::create(&opts.dest)
-        .wrap_err_with(|| format!("Failed to crate output file '{}'", opts.dest.display()))?;
+        .wrap_err_with(|| format!("Failed to create output file '{}'", opts.dest.display()))?;
     let mut dest_out = BufWriter::new(dest_file);
     let mut dest_db = store::Database::new();
+
+    let result;
+
+    if &opts.template != &PathBuf::from("") {
+        // fdb template
+        let template_file = File::open(&opts.template).wrap_err_with(|| {
+            format!("Failed to open fdb template '{}'", opts.template.display())
+        })?;
+        let mmap = unsafe { Mmap::map(&template_file)? };
+        let buffer: &[u8] = &mmap;
+        let template_db = Database::new(buffer);
+
+        result = convert_with_template(&conn, &mut dest_db, &template_db);
+    } else {
+        result = convert_without_template(&conn, &mut dest_db);
+    }
+
+    match result {
+        Ok(()) => {
+            dest_db
+                .write(&mut dest_out)
+                .wrap_err("Could not write output database")?;
+
+            let duration = start.elapsed();
+            println!(
+                "Finished in {}.{:#03}s",
+                duration.as_secs(),
+                duration.subsec_millis()
+            );
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}
+
+fn convert_without_template(
+    conn: &Connection,
+    dest_db: &mut assembly_fdb::store::Database,
+) -> eyre::Result<()> {
+    println!("Using direct SQLite -> FDB conversion.");
+    println!("Converting database, this may take a few seconds...");
 
     let tables_query = String::from("select name from sqlite_master where type='table'");
     let mut statement = conn.prepare(&tables_query)?;
@@ -53,10 +100,10 @@ fn main() -> eyre::Result<()> {
         for column in &statement.columns() {
             let decl_type = column
                 .decl_type()
-                .expect("The SQLite database is missing column type information.");
+                .expect("The SQLite database is missing column type information. Try converting using a template (see sqlite-to-fdb --help).");
 
             let target_type = ValueType::from_sqlite_type(decl_type)
-                .expect("The SQLite database contains an unknown column type.");
+                .expect("The SQLite database contains an unknown column type. Try converting using a template (see sqlite-to-fdb --help).");
 
             target_types.push(target_type);
         }
@@ -130,16 +177,128 @@ fn main() -> eyre::Result<()> {
         dest_db.push_table(Latin1String::encode(&table_name), dest_table);
     }
 
-    dest_db
-        .write(&mut dest_out)
-        .wrap_err("Could not write output database")?;
+    Ok(())
+}
 
-    let duration = start.elapsed();
-    println!(
-        "Finished in {}.{:#03}s",
-        duration.as_secs(),
-        duration.subsec_millis()
-    );
+fn convert_with_template(
+    conn: &Connection,
+    dest_db: &mut assembly_fdb::store::Database,
+    template_db: &Database,
+) -> eyre::Result<()> {
+    println!("Using template FDB for conversion.");
+    println!("Converting database, this may take a few seconds...");
+
+    for template_table in template_db.tables()?.iter() {
+        let template_table = template_table?;
+
+        // Find number of unique values in first column of source table
+        let unique_key_count = conn.query_row::<u32, _, _>(
+            &format!(
+                "select count(distinct [{}]) as unique_count from {}",
+                template_table
+                    .column_at(0)
+                    .ok_or_else(|| eyre!(format!(
+                        "FDB template contains no columns for table {}",
+                        template_table.name()
+                    )))?
+                    .name(),
+                template_table.name()
+            ),
+            rusqlite::NO_PARAMS,
+            |row| row.get(0),
+        )?;
+
+        // Bucket count should be 0 or a power of two
+        let new_bucket_count = if unique_key_count == 0 {
+            0
+        } else {
+            u32::next_power_of_two(unique_key_count)
+        };
+
+        // Create destination table
+        let mut dest_table = store::Table::new(new_bucket_count as usize);
+
+        // Number of columns destination table should have
+        let column_count = template_table.column_count();
+
+        // Vector to store target datatypes in as these can't be determined from the sqlite source db
+        let mut target_types: Vec<ValueType> = Vec::with_capacity(column_count);
+
+        // Build select query with the same column names and order as the template FDB
+        let mut select_query = String::from("select ");
+
+        // Write select query and store target datatypes
+        for (index, template_column) in template_table.column_iter().enumerate() {
+            let template_column_name = template_column.name();
+
+            write!(select_query, "[{}]", template_column_name)?;
+
+            if index < column_count - 1 {
+                write!(select_query, ", ")?;
+            }
+
+            target_types.push(template_column.value_type());
+
+            dest_table.push_column(template_column.name_raw(), template_column.value_type());
+        }
+
+        select_query.push_str(" from ");
+        select_query.push_str(&template_table.name());
+
+        // Execute query
+        let mut statement = conn.prepare(&select_query)?;
+        let mut rows = statement.query(rusqlite::NO_PARAMS)?;
+
+        // Iterate over rows
+        while let Some(sqlite_row) = rows.next()? {
+            let mut fields: Vec<Field> = Vec::with_capacity(column_count);
+
+            // Iterate over fields
+            #[allow(clippy::needless_range_loop)]
+            for index in 0..column_count {
+                fields.push(match sqlite_row.get_raw(index) {
+                    ValueRef::Null => Field::Nothing,
+                    ValueRef::Integer(i) => match target_types[index] {
+                        ValueType::Integer => Field::Integer(i as i32),
+                        ValueType::Boolean => Field::Boolean(i == 1),
+                        ValueType::BigInt => Field::BigInt(i),
+                        _ => {
+                            return Err(eyre!(
+                                "Invalid target datatype; cannot store SQLite Integer as FDB {:?}",
+                                target_types[index]
+                            ))
+                        }
+                    },
+                    ValueRef::Real(f) => Field::Float(f as f32),
+                    ValueRef::Text(t) => match target_types[index] {
+                        ValueType::Text => Field::Text(String::from(std::str::from_utf8(t)?)),
+                        ValueType::VarChar => Field::VarChar(String::from(std::str::from_utf8(t)?)),
+                        _ => {
+                            return Err(eyre!(
+                                "Invalid target datatype; cannot store SQLite Text as FDB {:?}",
+                                target_types[index]
+                            ))
+                        }
+                    },
+                    ValueRef::Blob(_b) => {
+                        return Err(eyre!("SQLite Blob datatype cannot be converted"))
+                    }
+                });
+            }
+
+            // Determine primary key to use for bucket index
+            let pk = match &fields[0] {
+                Field::Integer(i) => *i as usize,
+                Field::BigInt(i) => *i as usize,
+                Field::Text(t) => (sfhash::digest(t.as_bytes())) as usize,
+                _ => return Err(eyre!("Cannot use {:?} as primary key", &fields[0])),
+            };
+
+            dest_table.push_row(pk, &fields);
+        }
+
+        dest_db.push_table(template_table.name_raw(), dest_table);
+    }
 
     Ok(())
 }

--- a/modules/fdb/examples/sqlite-to-fdb.rs
+++ b/modules/fdb/examples/sqlite-to-fdb.rs
@@ -16,8 +16,8 @@ struct Options {
     /// Output FDB file
     dest: PathBuf,
     /// Optional: an FDB file containing tables with correct columns but no rows used to determine type information
-    #[structopt(long, default_value = "")]
-    template: PathBuf,
+    #[structopt(long)]
+    template: Option<PathBuf>,
 }
 
 fn main() -> eyre::Result<()> {
@@ -38,11 +38,10 @@ fn main() -> eyre::Result<()> {
 
     let result;
 
-    if &opts.template != &PathBuf::from("") {
+    if let Some(template) = &opts.template {
         // fdb template
-        let template_file = File::open(&opts.template).wrap_err_with(|| {
-            format!("Failed to open fdb template '{}'", opts.template.display())
-        })?;
+        let template_file = File::open(template)
+            .wrap_err_with(|| format!("Failed to open fdb template '{}'", template.display()))?;
         let mmap = unsafe { Mmap::map(&template_file)? };
         let buffer: &[u8] = &mmap;
         let template_db = Database::new(buffer);

--- a/modules/fdb/examples/sqlite-to-fdb.rs
+++ b/modules/fdb/examples/sqlite-to-fdb.rs
@@ -1,6 +1,6 @@
-use assembly_fdb::{common::ValueType, core::Field, mem::Database, store};
+use assembly_fdb::{common::Latin1String, common::ValueType, core::Field, store};
 use color_eyre::eyre::{self, eyre, WrapErr};
-use mapr::Mmap;
+
 use rusqlite::{types::ValueRef, Connection};
 use std::{fmt::Write, fs::File, io::BufWriter, path::PathBuf, time::Instant};
 use structopt::StructOpt;
@@ -8,8 +8,6 @@ use structopt::StructOpt;
 #[derive(StructOpt)]
 /// Fills a template FDB file (see template-fdb.rs) with rows from a sqlite database
 struct Options {
-    /// "Template" FDB file, the table structure from this will be used for the output
-    template: PathBuf,
     /// Input sqlite database
     src: PathBuf,
     /// Output FDB file
@@ -23,13 +21,6 @@ fn main() -> eyre::Result<()> {
 
     println!("Converting database, this may take a few seconds...");
 
-    // fdb template
-    let template_file = File::open(&opts.template)
-        .wrap_err_with(|| format!("Failed to open fdb template '{}'", opts.template.display()))?;
-    let mmap = unsafe { Mmap::map(&template_file)? };
-    let buffer: &[u8] = &mmap;
-    let template_db = Database::new(buffer);
-
     // sqlite input
     let conn = Connection::open_with_flags(&opts.src, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
         .wrap_err_with(|| format!("Failed to open sqlite file '{}'", opts.src.display()))?;
@@ -40,25 +31,53 @@ fn main() -> eyre::Result<()> {
     let mut dest_out = BufWriter::new(dest_file);
     let mut dest_db = store::Database::new();
 
-    for template_table in template_db.tables()?.iter() {
-        let template_table = template_table?;
+    let tables_query = String::from("select name from sqlite_master where type='table'");
+    let mut statement = conn.prepare(&tables_query)?;
+    let table_names = statement.query_map::<String, _, _>(rusqlite::NO_PARAMS, |row| row.get(0))?;
+
+    for table_name in table_names {
+        let table_name = table_name?;
+
+        println!("");
+        println!("Processing table '{}'", table_name);
+
+        // Build select query with the same column names and order as the template FDB
+        let mut select_query = String::from("select * from ");
+        select_query.push_str(&table_name);
+
+        // Prepare statement
+        let mut statement = conn.prepare(&select_query)?;
+
+        // Number of columns destination table should have
+        let column_count = statement.columns().len();
+
+        // Vector to store target datatypes in as these can't be determined from the sqlite source db
+        let mut target_types: Vec<ValueType> = Vec::with_capacity(column_count);
+
+        // Get column types
+        for column in &statement.columns() {
+            let decl_type = column.decl_type().expect("Failed to get column type");
+
+            let target_type =
+                ValueType::from_sqlite_type(decl_type).expect("Failed to convert column type");
+
+            target_types.push(target_type);
+
+            println!("Column '{}' has type '{}'", column.name(), target_type);
+        }
 
         // Find number of unique values in first column of source table
         let unique_key_count = conn.query_row::<u32, _, _>(
             &format!(
                 "select count(distinct [{}]) as unique_count from {}",
-                template_table
-                    .column_at(0)
-                    .ok_or_else(|| eyre!(format!(
-                        "FDB template contains no columns for table {}",
-                        template_table.name()
-                    )))?
-                    .name(),
-                template_table.name()
+                statement.columns().get(0).unwrap().name(),
+                table_name
             ),
             rusqlite::NO_PARAMS,
             |row| row.get(0),
         )?;
+
+        println!("Number of unique keys: {}", unique_key_count);
 
         // Bucket count should be 0 or a power of two
         let new_bucket_count = if unique_key_count == 0 {
@@ -70,35 +89,12 @@ fn main() -> eyre::Result<()> {
         // Create destination table
         let mut dest_table = store::Table::new(new_bucket_count as usize);
 
-        // Number of columns destination table should have
-        let column_count = template_table.column_count();
-
-        // Vector to store target datatypes in as these can't be determined from the sqlite source db
-        let mut target_types: Vec<ValueType> = Vec::with_capacity(column_count);
-
-        // Build select query with the same column names and order as the template FDB
-        let mut select_query = String::from("select ");
-
-        // Write select query and store target datatypes
-        for (index, template_column) in template_table.column_iter().enumerate() {
-            let template_column_name = template_column.name();
-
-            write!(select_query, "[{}]", template_column_name)?;
-
-            if index < column_count - 1 {
-                write!(select_query, ", ")?;
-            }
-
-            target_types.push(template_column.value_type());
-
-            dest_table.push_column(template_column.name_raw(), template_column.value_type());
+        // Add columns to destination table
+        for (i, column) in statement.columns().iter().enumerate() {
+            dest_table.push_column(Latin1String::encode(column.name()), *target_types.get(i).unwrap());
         }
 
-        select_query.push_str(" from ");
-        select_query.push_str(&template_table.name());
-
         // Execute query
-        let mut statement = conn.prepare(&select_query)?;
         let mut rows = statement.query(rusqlite::NO_PARAMS)?;
 
         // Iterate over rows
@@ -149,7 +145,7 @@ fn main() -> eyre::Result<()> {
             dest_table.push_row(pk, &fields);
         }
 
-        dest_db.push_table(template_table.name_raw(), dest_table);
+        dest_db.push_table(Latin1String::encode(&table_name), dest_table);
     }
 
     dest_db


### PR DESCRIPTION
This now uses the extra type info contained in the SQLite DB to determine the target datatypes.

If desired we could keep the old version around as a separate tool to convert old SQLite files without type info, although I doubt this is necessary given most people have used lcdr's fdb_to_sqlite previously which already included this information.