### PR TITLE
Fix cursor not being reset on sqlite calling filter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
     "rust-analyzer.linkedProjects": [
         "Cargo.toml"
     ],
-    "rust-analyzer.cargo.features": "all"
+    "rust-analyzer.cargo.features": "all",
+    "rust-analyzer.showUnlinkedFileNotification": false
 }

--- a/modules/fdb/Cargo.toml
+++ b/modules/fdb/Cargo.toml
@@ -15,8 +15,9 @@ io-write = []
 store = ["io-write"]
 core = []
 core-loader = ["io-read", "core"]
-default = ["serde-derives"]
+default = ["sqlite-vtab", "serde-derives"]
 sqlite = ["rusqlite", "assembly-fdb-core/sqlite"]
+sqlite-vtab = ["sqlite", "rusqlite/vtab"]
 serde-derives = ["serde", "latin1str/serde", "assembly-fdb-core/serde"]
 bytemuck = ["assembly-fdb-core/bytemuck"]
 
@@ -69,6 +70,7 @@ mapr = "0.8"
 argh = "0.1.9"
 color-eyre = "0.5"
 serde_json = "1.0.61"
+rustyline = "9.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/modules/fdb/examples/fdbsh.rs
+++ b/modules/fdb/examples/fdbsh.rs
@@ -19,6 +19,7 @@ fn exec(conn: &rusqlite::Connection, sql: &str) -> rusqlite::Result<()> {
     let mut stmt = conn.prepare(sql)?;
     let col_count = stmt.column_count();
     let mut table = prettytable::Table::new();
+    table.set_format(*prettytable::format::consts::FORMAT_NO_LINESEP_WITH_TITLE);
     table.set_titles(prettytable::Row::new(
         stmt.column_names()
             .into_iter()
@@ -79,11 +80,12 @@ fn main() -> color_eyre::Result<()> {
         let name = table.name();
 
         if name == "DBExclude" {
+            println!("Skipping {:?}", name); // FIXME
             continue;
         }
 
         let sql = format!("CREATE VIRTUAL TABLE {} USING fdb;", name);
-        println!("Running: {}", sql);
+        //println!("Running: {}", sql);
         conn.execute(&sql, [])?;
     }
 

--- a/modules/fdb/examples/fdbsh.rs
+++ b/modules/fdb/examples/fdbsh.rs
@@ -1,0 +1,82 @@
+use std::{fs::File, path::PathBuf};
+
+use argh::FromArgs;
+use assembly_fdb::mem;
+use color_eyre::eyre::Context;
+use mapr::Mmap;
+use rusqlite::Connection;
+use rustyline::error::ReadlineError;
+
+#[derive(FromArgs)]
+/// turns an FDB file into an equivalent SQLite file
+struct Options {
+    /// the FD source file
+    #[argh(positional)]
+    src: PathBuf,
+}
+
+fn exec(conn: &rusqlite::Connection, sql: &str) -> rusqlite::Result<()> {
+    let mut stmt = conn.prepare(sql)?;
+    let col_count = stmt.column_count();
+    let mut rows = stmt.query([])?;
+
+    while let Some(row) = rows.next()? {
+        for idx in 0..col_count {
+            let value = row.get_ref(idx)?;
+            match value {
+                rusqlite::types::ValueRef::Null => print!(" null"),
+                rusqlite::types::ValueRef::Integer(i) => print!(" {}", i),
+                rusqlite::types::ValueRef::Real(r) => print!(" {}", r),
+                rusqlite::types::ValueRef::Text(t) => {
+                    print!(" {:?}", std::str::from_utf8(t).unwrap())
+                }
+                rusqlite::types::ValueRef::Blob(b) => print!(" {:?}", b),
+            }
+        }
+        println!();
+    }
+    Ok(())
+}
+
+fn main() -> color_eyre::Result<()> {
+    let opts: Options = argh::from_env();
+
+    let src_file = File::open(&opts.src)
+        .wrap_err_with(|| format!("Failed to open input file '{}'", opts.src.display()))?;
+    let mmap = unsafe { Mmap::map(&src_file)? };
+    let buffer: &[u8] = &mmap;
+
+    let _db = mem::Database::new(buffer);
+    let conn = Connection::open_in_memory()?;
+
+    let mut rl = rustyline::Editor::<()>::new();
+
+    loop {
+        let readline = rl.readline(">> ");
+        match readline {
+            Ok(line) => {
+                rl.add_history_entry(&line);
+                if let Some(x) = line.strip_prefix('.') {
+                    match x {
+                        "exit" => break,
+                        "help" => {
+                            println!("Commands:");
+                            println!(" exit");
+                            println!(" help");
+                        }
+                        _ => println!("Unknown command {:?}", x),
+                    }
+                } else {
+                    match exec(&conn, &line) {
+                        Ok(()) => {}
+                        Err(e) => println!("ERROR: {}", e),
+                    }
+                }
+            }
+            Err(ReadlineError::Interrupted) => break,
+            Err(_) => println!("No input"),
+        }
+    }
+
+    Ok(())
+}

--- a/modules/fdb/examples/sqlite-to-fdb.rs
+++ b/modules/fdb/examples/sqlite-to-fdb.rs
@@ -110,9 +110,7 @@ fn main() -> eyre::Result<()> {
     let mut dest_out = BufWriter::new(dest_file);
     let mut dest_db = store::Database::new();
 
-    let result;
-
-    if let Some(template) = &opts.template {
+    let result = if let Some(template) = &opts.template {
         // fdb template
         let template_file = File::open(template)
             .wrap_err_with(|| format!("Failed to open fdb template '{}'", template.display()))?;
@@ -120,10 +118,10 @@ fn main() -> eyre::Result<()> {
         let buffer: &[u8] = &mmap;
         let template_db = Database::new(buffer);
 
-        result = convert_with_template(&conn, &mut dest_db, &template_db);
+        convert_with_template(&conn, &mut dest_db, &template_db)
     } else {
-        result = convert_without_template(&conn, &mut dest_db);
-    }
+        convert_without_template(&conn, &mut dest_db)
+    };
 
     match result {
         Ok(()) => {

--- a/modules/fdb/src/mem/mod.rs
+++ b/modules/fdb/src/mem/mod.rs
@@ -201,6 +201,7 @@ struct InnerTable<'a> {
 }
 
 #[derive(Copy, Clone)]
+#[repr(C)]
 /// Reference to a single table
 pub struct Table<'a> {
     inner: Handle<'a, InnerTable<'a>>,

--- a/modules/fdb/src/mem/mod.rs
+++ b/modules/fdb/src/mem/mod.rs
@@ -231,6 +231,14 @@ impl<'a> Table<'a> {
         })
     }
 
+    /// Get a list of all rows in the bucket of a given index
+    pub fn bucket_index_iter(&self, id: u32) -> TableRowIter<'a> {
+        let bucket: usize = id as usize % self.bucket_count();
+        TableRowIter::new(BucketIter::new(
+            &self.inner.map_val(|r| &r.buckets[bucket..bucket + 1]),
+        ))
+    }
+
     /// Get the column at the index
     ///
     /// **Note**: This does some computation, call only once per colum if possible

--- a/modules/fdb/src/sqlite/mod.rs
+++ b/modules/fdb/src/sqlite/mod.rs
@@ -5,7 +5,10 @@ use std::fmt::Write;
 use rusqlite::params_from_iter;
 pub use rusqlite::{Connection, Error, Result};
 
+#[cfg(feature = "sqlite-vtab")]
 mod vtab;
+#[cfg(feature = "sqlite-vtab")]
+pub use vtab::load_module;
 
 use super::mem::Database;
 

--- a/modules/fdb/src/sqlite/mod.rs
+++ b/modules/fdb/src/sqlite/mod.rs
@@ -5,6 +5,8 @@ use std::fmt::Write;
 use rusqlite::params_from_iter;
 pub use rusqlite::{Connection, Error, Result};
 
+mod vtab;
+
 use super::mem::Database;
 
 /// Try to export a database to a SQL connection

--- a/modules/fdb/src/sqlite/vtab.rs
+++ b/modules/fdb/src/sqlite/vtab.rs
@@ -1,6 +1,6 @@
 //! # Virtual Table implementation
 
-use rusqlite::vtab::{CreateVTab, VTab, VTabCursor};
+use rusqlite::vtab::{read_only_module, CreateVTab, VTab, VTabCursor};
 
 use crate::mem;
 
@@ -10,6 +10,14 @@ struct FdbTab<'vtab> {
     base: rusqlite::vtab::sqlite3_vtab,
     /* Virtual table implementations will typically add additional fields */
     table: mem::Table<'vtab>,
+}
+
+/// Register the module
+pub fn load_module(
+    conn: &rusqlite::Connection,
+    db: mem::Database<'static>,
+) -> rusqlite::Result<()> {
+    conn.create_module("fdb", read_only_module::<FdbTab>(), Some(db))
 }
 
 struct BufferedIter<'vtab> {

--- a/modules/fdb/src/sqlite/vtab.rs
+++ b/modules/fdb/src/sqlite/vtab.rs
@@ -1,0 +1,185 @@
+//! # Virtual Table implementation
+
+use rusqlite::vtab::{CreateVTab, VTab, VTabCursor};
+
+use crate::mem;
+
+#[repr(C)]
+struct FdbTab<'vtab> {
+    /// Base class. Must be first
+    base: rusqlite::vtab::sqlite3_vtab,
+    /* Virtual table implementations will typically add additional fields */
+    table: mem::Table<'vtab>,
+}
+
+struct BufferedIter<'vtab> {
+    /// The backing iterator
+    iter: mem::iter::TableRowIter<'vtab>,
+    /// The item at the front
+    next: Option<mem::Row<'vtab>>,
+    /// The rowid
+    rowid: i64,
+}
+
+impl<'vtab> BufferedIter<'vtab> {
+    pub fn new(table: mem::Table<'vtab>) -> Self {
+        let mut iter = table.row_iter();
+        let next = iter.next();
+        Self {
+            iter,
+            next,
+            rowid: 0,
+        }
+    }
+
+    #[inline]
+    pub fn eof(&self) -> bool {
+        self.next.is_none()
+    }
+
+    pub fn next(&mut self) {
+        self.next = self.iter.next();
+        self.rowid += 1;
+    }
+}
+
+#[repr(C)]
+struct FdbTabCursor<'vtab> {
+    /// Base class. Must be first
+    base: rusqlite::vtab::sqlite3_vtab_cursor,
+    /* Virtual table implementations will typically add additional fields */
+    iter: BufferedIter<'vtab>,
+}
+
+unsafe impl<'vtab> VTabCursor for FdbTabCursor<'vtab> {
+    fn filter(
+        &mut self,
+        _idx_num: std::os::raw::c_int,
+        _idx_str: Option<&str>,
+        _args: &rusqlite::vtab::Values<'_>,
+    ) -> rusqlite::Result<()> {
+        Ok(())
+    }
+
+    fn next(&mut self) -> rusqlite::Result<()> {
+        self.iter.next(); // Just drop the next one
+        Ok(())
+    }
+
+    fn eof(&self) -> bool {
+        self.iter.eof()
+    }
+
+    fn column(
+        &self,
+        ctx: &mut rusqlite::vtab::Context,
+        i: std::os::raw::c_int,
+    ) -> rusqlite::Result<()> {
+        // Get the row
+        let row = self.iter.next.ok_or_else(|| {
+            rusqlite::Error::ModuleError(format!(
+                "FDB: no data for col {} past the end of the table",
+                i
+            ))
+        })?;
+
+        // Get the field
+        let field = row.field_at(i as usize).ok_or_else(|| {
+            rusqlite::Error::ModuleError(format!("FDB: column {} out of bounds", i))
+        })?;
+
+        // Return the result
+        ctx.set_result(&field)?;
+
+        Ok(())
+    }
+
+    fn rowid(&self) -> rusqlite::Result<i64> {
+        Ok(self.iter.rowid)
+    }
+}
+
+unsafe impl<'vtab> VTab<'vtab> for FdbTab<'vtab> {
+    type Aux = mem::Database<'vtab>;
+
+    type Cursor = FdbTabCursor<'vtab>;
+
+    fn connect(
+        _db: &mut rusqlite::vtab::VTabConnection,
+        aux: Option<&Self::Aux>,
+        args: &[&[u8]],
+    ) -> rusqlite::Result<(String, Self)> {
+        match *args {
+            [] => Err(rusqlite::Error::InvalidParameterCount(0, 1)),
+            [mod_name, db_name, table_name] => {
+                let name = std::str::from_utf8(table_name).map_err(|e| {
+                    rusqlite::Error::ModuleError(format!("FDB: Table name is invalid UTF-8: {}", e))
+                })?;
+
+                let table = aux
+                    .ok_or_else(|| {
+                        rusqlite::Error::ModuleError(format!(
+                            "Missing 'aux' for FDB vtab ({:?},{:?},{:?})",
+                            mod_name, db_name, table_name
+                        ))
+                    })?
+                    .tables()
+                    .map_err(|e| {
+                        rusqlite::Error::ModuleError(format!("FDB: Failed to get [Tables]: {}", e))
+                    })?
+                    .by_name(name)
+                    .ok_or_else(|| {
+                        rusqlite::Error::ModuleError(format!("FDB: Unknown table {:?}", name))
+                    })?
+                    .map_err(|e| {
+                        rusqlite::Error::ModuleError(format!("FDB: Failed to get [Tables]: {}", e))
+                    })?;
+
+                let mut schema = String::from("CREATE TABLE x(");
+                for (index, col) in table.column_iter().enumerate() {
+                    if index > 0 {
+                        schema.push_str(", ");
+                    }
+                    schema.push_str(col.name().as_ref());
+                    schema.push(' ');
+                    schema.push_str(col.value_type().to_sqlite_type());
+                }
+                schema.push_str(");");
+
+                let vtab = FdbTab {
+                    base: rusqlite::vtab::sqlite3_vtab::default(),
+                    table,
+                };
+
+                Ok((schema, vtab))
+            }
+            _ => Err(rusqlite::Error::InvalidParameterCount(args.len(), 1)),
+        }
+    }
+
+    fn best_index(&self, info: &mut rusqlite::vtab::IndexInfo) -> rusqlite::Result<()> {
+        info.set_estimated_cost(1_000_000.0);
+        Ok(())
+    }
+
+    fn open(&'vtab self) -> rusqlite::Result<Self::Cursor> {
+        Ok(FdbTabCursor {
+            base: rusqlite::vtab::sqlite3_vtab_cursor::default(),
+            iter: BufferedIter::new(self.table),
+        })
+    }
+}
+
+impl<'vtab> CreateVTab<'vtab> for FdbTab<'vtab> {
+    fn create(
+        db: &mut rusqlite::vtab::VTabConnection,
+        aux: Option<&Self::Aux>,
+        args: &[&[u8]],
+    ) -> rusqlite::Result<(String, Self)> {
+        Self::connect(db, aux, args)
+    }
+
+    fn destroy(&self) -> rusqlite::Result<()> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
Long awaited, but now I finally got around to it: This fixes sqlite vtab not working due to `filter` not resetting the iterator and thus the iterator being exhausted prematurely.